### PR TITLE
Fix MPKGHeader.version output by limiting string length

### DIFF
--- a/unmpkg.c
+++ b/unmpkg.c
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
 		return -1;
 	}
 	printf("Version Long: %u\n", mpkg_header.version_length);
-	printf("Version : %s\n", mpkg_header.version);
+	printf("Version : %.8s\n", mpkg_header.version);
 	printf("Num of file : %u\n", mpkg_header.file_total);
 
 	// read mpkgfile entries


### PR DESCRIPTION
Fix MPKGHeader.version output by limiting string length

- Change printf format specifier from %s to %.8s for MPKGHeader.version
- Ensure only 8 characters are printed to avoid undefined behavior
